### PR TITLE
ITの正常系からモックを除去（mock-policy準拠）

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,141 @@
+"""Shared fixtures for integration tests.
+
+Provides local Parquet-backed datasets for CLI integration tests,
+eliminating the need to mock ``load_hf_dataset`` in normal-path tests.
+
+Each fixture creates a temporary directory containing a single Parquet
+file and returns the directory path (str) which can be passed directly
+as the ``DATASET_ID`` argument to the CLI.
+"""
+
+from __future__ import annotations
+
+import pytest
+from datasets import Dataset, disable_progress_bars
+
+# Suppress HuggingFace datasets progress bars globally so that tqdm output
+# does not pollute CliRunner's captured stdout during integration tests.
+disable_progress_bars()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _save_dataset_to_parquet(dataset: Dataset, tmp_path) -> str:
+    """Persist *dataset* as a Parquet file inside a ``data/`` sub-directory.
+
+    A sub-directory is used so that fixtures and the test function can
+    both use ``tmp_path`` without interfering with each other (e.g. a
+    YAML config written by the test won't be in the dataset directory).
+    """
+    data_dir = tmp_path / "data"
+    data_dir.mkdir(exist_ok=True)
+    dataset.to_parquet(str(data_dir / "train-00000-of-00001.parquet"))
+    return str(data_dir)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def clean_dataset_path(tmp_path) -> str:
+    """5-row clean dataset with no quality issues.
+
+    Each text is >50 characters, English, and unique (avoids
+    near-duplicate warnings).
+    """
+    unique_contents = [
+        "The quick brown fox jumps over the lazy dog with agility and grace.",
+        "Machine learning algorithms process large amounts of data efficiently.",
+        "Natural language processing enables computers to understand human speech.",
+        "Data science combines statistics, mathematics, and programming effectively.",
+        "Cloud computing provides scalable infrastructure for modern applications.",
+    ]
+    texts = [content + f" Document {i}." for i, content in enumerate(unique_contents)]
+    ds = Dataset.from_dict({"text": texts})
+    return _save_dataset_to_parquet(ds, tmp_path)
+
+
+@pytest.fixture()
+def warning_dataset_path(tmp_path) -> str:
+    """2-row dataset containing a short text that triggers TextLengthChecker WARNING."""
+    ds = Dataset.from_dict({
+        "text": [
+            "Short",  # <50 chars -> WARNING
+            "This is a normal document with sufficient text length for quality checks.",
+        ]
+    })
+    return _save_dataset_to_parquet(ds, tmp_path)
+
+
+@pytest.fixture()
+def error_dataset_path(tmp_path) -> str:
+    """2-row dataset with a None text field that triggers MissingFieldChecker ERROR."""
+    ds = Dataset.from_dict({
+        "text": [None, "Normal text with sufficient length for quality checks."]
+    })
+    return _save_dataset_to_parquet(ds, tmp_path)
+
+
+@pytest.fixture()
+def html_control_chars_dataset_path(tmp_path) -> str:
+    """3-row dataset with HTML tags and control characters (for --fix / --dry-run tests)."""
+    ds = Dataset.from_dict({
+        "text": [
+            "<p>Hello <b>world</b></p>",
+            "Text with\x00control chars",
+            "Normal clean text without any issues at all.",
+        ]
+    })
+    return _save_dataset_to_parquet(ds, tmp_path)
+
+
+@pytest.fixture()
+def long_text_dataset_path_5001(tmp_path) -> str:
+    """2-row dataset: one 5001-char text + one normal text."""
+    ds = Dataset.from_dict({
+        "text": [
+            "x" * 5001,
+            "This is a normal document with sufficient text length for quality checks.",
+        ]
+    })
+    return _save_dataset_to_parquet(ds, tmp_path)
+
+
+@pytest.fixture()
+def long_text_dataset_path_5000(tmp_path) -> str:
+    """2-row dataset: one exactly-5000-char text + one normal text."""
+    ds = Dataset.from_dict({
+        "text": [
+            "x" * 5000,
+            "This is a normal document with sufficient text length for quality checks.",
+        ]
+    })
+    return _save_dataset_to_parquet(ds, tmp_path)
+
+
+@pytest.fixture()
+def near_duplicate_dataset_path(tmp_path) -> str:
+    """2-row dataset with nearly identical texts for NearDuplicateChecker detection."""
+    base = "word " * 100  # 100-word identical content
+    variant = base[:-1] + "X"  # last char differs
+    ds = Dataset.from_dict({"text": [base, variant]})
+    return _save_dataset_to_parquet(ds, tmp_path)
+
+
+@pytest.fixture()
+def large_dataset_path(tmp_path) -> str:
+    """1,100+ row dataset for --sample-size tests (AC-14-04 requires 1,000+)."""
+    ds = Dataset.from_dict({
+        "text": [
+            f"This is document number {i:04d}, a unique entry in this large dataset. "
+            "It has sufficient length to pass the text length checker "
+            "and contains absolutely no quality issues whatsoever."
+            for i in range(1100)
+        ]
+    })
+    return _save_dataset_to_parquet(ds, tmp_path)

--- a/tests/integration/test_checker_config_integration.py
+++ b/tests/integration/test_checker_config_integration.py
@@ -7,39 +7,10 @@ Source: docs/design.md — CheckerConfig と YAML 設定ファイル 受入条�
 
 import json
 
-import pytest
 from click.testing import CliRunner
-from datasets import Dataset
-from unittest.mock import patch
 
 from evaldataset.cli import main
 from evaldataset.config import CheckerConfig
-
-
-# ---------------------------------------------------------------------------
-# テスト用データセットファクトリ
-# ---------------------------------------------------------------------------
-
-
-def _dataset_with_long_text(char_count: int) -> Dataset:
-    """指定文字数のテキストを1件含み、正常な短いテキストを1件含むデータセット。"""
-    return Dataset.from_dict({
-        "text": [
-            "x" * char_count,
-            "This is a normal document with sufficient text length for quality checks.",
-        ]
-    })
-
-
-def _near_duplicate_dataset() -> Dataset:
-    """near-duplicate チェッカーが検出するような類似テキストペアを含むデータセット。
-
-    1文字だけ違う極めて類似したテキストペア。NearDuplicateChecker が
-    実行された場合は WARNING を検出する。
-    """
-    base = "word " * 100  # 100語の同一内容
-    variant = base[:-1] + "X"  # 最後の1文字だけ違う
-    return Dataset.from_dict({"text": [base, variant]})
 
 
 # ---------------------------------------------------------------------------
@@ -166,7 +137,9 @@ class TestCheckerConfigCliIntegration:
     Source: docs/design.md — CheckerConfig と YAML 設定ファイル 受入条件 (AC-15-03)
     """
 
-    def test_config_yaml_max_length_causes_warning_for_exceeding_text(self, tmp_path):
+    def test_config_yaml_max_length_causes_warning_for_exceeding_text(
+        self, tmp_path, long_text_dataset_path_5001,
+    ):
         """
         AC-15-03: --config オプションでの CLI 連携
 
@@ -178,21 +151,17 @@ class TestCheckerConfigCliIntegration:
         config_file = tmp_path / "custom_config.yaml"
         config_file.write_text("max_length: 5000\n")
 
-        # 5,001 文字のテキストを含むデータセット（max_length=5000 を超過する）
-        dataset = _dataset_with_long_text(5001)
-
         runner = CliRunner()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(
-                main,
-                [
-                    "test/dataset",
-                    "--config", str(config_file),
-                    "--output", "json",
-                ],
-            )
+        result = runner.invoke(
+            main,
+            [
+                long_text_dataset_path_5001,
+                "--config", str(config_file),
+                "--output", "json",
+            ],
+        )
 
         # Assert (Then)
         assert result.exit_code in (1, 2), (
@@ -224,7 +193,9 @@ class TestCheckerConfigCliIntegration:
             f"with max_length=5000. issues: {issues}"
         )
 
-    def test_config_yaml_max_length_no_warning_for_within_limit_text(self, tmp_path):
+    def test_config_yaml_max_length_no_warning_for_within_limit_text(
+        self, tmp_path, long_text_dataset_path_5000,
+    ):
         """
         AC-15-03 補足: max_length: 5000 の設定で 5,000 文字のテキストは WARNING なし
 
@@ -236,21 +207,17 @@ class TestCheckerConfigCliIntegration:
         config_file = tmp_path / "custom_config.yaml"
         config_file.write_text("max_length: 5000\n")
 
-        # ちょうど 5,000 文字（境界値 = 許容範囲内）のデータセット
-        dataset = _dataset_with_long_text(5000)
-
         runner = CliRunner()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(
-                main,
-                [
-                    "test/dataset",
-                    "--config", str(config_file),
-                    "--output", "json",
-                ],
-            )
+        result = runner.invoke(
+            main,
+            [
+                long_text_dataset_path_5000,
+                "--config", str(config_file),
+                "--output", "json",
+            ],
+        )
 
         # Assert (Then)
         output_data = json.loads(result.output)
@@ -286,7 +253,9 @@ class TestCheckerConfigSkipCheckers:
     Source: docs/design.md — CheckerConfig と YAML 設定ファイル 受入条件 (AC-15-04)
     """
 
-    def test_skip_near_duplicate_checker_via_yaml(self, tmp_path):
+    def test_skip_near_duplicate_checker_via_yaml(
+        self, tmp_path, near_duplicate_dataset_path,
+    ):
         """
         AC-15-04: skip_checkers によるチェッカースキップ
 
@@ -298,21 +267,17 @@ class TestCheckerConfigSkipCheckers:
         config_file = tmp_path / "skip_config.yaml"
         config_file.write_text('skip_checkers:\n  - "near_duplicate"\n')
 
-        # 類似テキストを含むデータセット（NearDuplicateChecker が実行されれば WARNING が出る）
-        dataset = _near_duplicate_dataset()
-
         runner = CliRunner()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(
-                main,
-                [
-                    "test/dataset",
-                    "--config", str(config_file),
-                    "--output", "json",
-                ],
-            )
+        result = runner.invoke(
+            main,
+            [
+                near_duplicate_dataset_path,
+                "--config", str(config_file),
+                "--output", "json",
+            ],
+        )
 
         # Assert (Then)
         assert result.exit_code in (0, 1, 2), (
@@ -332,7 +297,9 @@ class TestCheckerConfigSkipCheckers:
             f"NearDuplicateChecker should be skipped but found results: {near_dup_results}"
         )
 
-    def test_skip_near_duplicate_checker_via_cli_option(self):
+    def test_skip_near_duplicate_checker_via_cli_option(
+        self, near_duplicate_dataset_path,
+    ):
         """
         AC-15-04 補足: --skip-checker CLI オプションによるチェッカースキップ
 
@@ -344,19 +311,17 @@ class TestCheckerConfigSkipCheckers:
         （設定マージ優先順位: CLI > YAML > デフォルト）
         """
         # Arrange (Given)
-        dataset = _near_duplicate_dataset()
         runner = CliRunner()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(
-                main,
-                [
-                    "test/dataset",
-                    "--skip-checker", "near_duplicate",
-                    "--output", "json",
-                ],
-            )
+        result = runner.invoke(
+            main,
+            [
+                near_duplicate_dataset_path,
+                "--skip-checker", "near_duplicate",
+                "--output", "json",
+            ],
+        )
 
         # Assert (Then)
         assert result.exit_code in (0, 1, 2), (

--- a/tests/integration/test_cli_integration.py
+++ b/tests/integration/test_cli_integration.py
@@ -12,76 +12,9 @@ import tempfile
 
 import pytest
 from click.testing import CliRunner
-from datasets import Dataset
 from unittest.mock import patch
 
 from evaldataset.cli import main
-
-
-# ---------------------------------------------------------------------------
-# テスト用データセットファクトリ
-# ---------------------------------------------------------------------------
-
-def _clean_dataset(n: int = 5) -> Dataset:
-    """品質問題がない正常なデータセット（n件）を返す。
-
-    各テキストはユニークな内容にし、near-duplicate WARNING を回避する。
-    """
-    unique_contents = [
-        "The quick brown fox jumps over the lazy dog with agility and grace.",
-        "Machine learning algorithms process large amounts of data efficiently.",
-        "Natural language processing enables computers to understand human speech.",
-        "Data science combines statistics, mathematics, and programming effectively.",
-        "Cloud computing provides scalable infrastructure for modern applications.",
-        "Artificial intelligence transforms industries and reshapes human work patterns.",
-        "Software engineering requires careful design, testing, and documentation practices.",
-        "Database systems store and retrieve structured information with reliability.",
-        "Network security protects digital assets from unauthorized access and threats.",
-        "Web development creates interactive applications using modern browser technologies.",
-    ]
-    texts = [unique_contents[i % len(unique_contents)] + f" Document {i}."
-             for i in range(n)]
-    return Dataset.from_dict({"text": texts})
-
-
-def _dataset_with_warnings() -> Dataset:
-    """WARNING レベルの Issue（短すぎるテキスト）を含むデータセットを返す。"""
-    return Dataset.from_dict({
-        "text": [
-            "Short",  # 50文字未満 → TextLengthChecker が WARNING を発生させる
-            "This is a normal document with sufficient text length for quality checks.",
-        ]
-    })
-
-
-def _dataset_with_errors() -> Dataset:
-    """ERROR レベルの Issue（Noneフィールド）を含むデータセットを返す。"""
-    return Dataset.from_dict({
-        "text": [None, "Normal text with sufficient length for quality checks."]
-    })
-
-
-def _large_dataset(n: int = 200) -> Dataset:
-    """1,000件未満だが --sample-size テスト用の十分なサイズのデータセット。"""
-    return Dataset.from_dict({
-        "text": [
-            f"This is document number {i}. "
-            "It has sufficient length to pass the text length checker "
-            "and contains absolutely no quality issues."
-            for i in range(n)
-        ]
-    })
-
-
-def _dataset_with_html_and_control_chars() -> Dataset:
-    """HTMLタグと制御文字を含むデータセット（--fix テスト用）。"""
-    return Dataset.from_dict({
-        "text": [
-            "<p>Hello <b>world</b></p>",
-            "Text with\x00control chars",
-            "Normal clean text without any issues at all.",
-        ]
-    })
 
 
 # ---------------------------------------------------------------------------
@@ -94,7 +27,7 @@ class TestCliNormalExecution:
     Source: docs/design.md — CLI 受入条件 AC-14-01
     """
 
-    def test_clean_dataset_exits_zero(self):
+    def test_clean_dataset_exits_zero(self, clean_dataset_path):
         """
         AC-14-01: 正常実行（基本フロー）
 
@@ -104,18 +37,16 @@ class TestCliNormalExecution:
         """
         # Arrange (Given)
         runner = CliRunner()
-        dataset = _clean_dataset()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(main, ["test/clean-dataset"])
+        result = runner.invoke(main, [clean_dataset_path])
 
         # Assert (Then)
         assert result.exit_code == 0, (
             f"Expected exit code 0, got {result.exit_code}. Output:\n{result.output}"
         )
 
-    def test_clean_dataset_shows_checker_results(self):
+    def test_clean_dataset_shows_checker_results(self, clean_dataset_path):
         """
         AC-14-01: 正常実行 — 全チェッカーの結果がコンソールに表示される
 
@@ -125,12 +56,10 @@ class TestCliNormalExecution:
         """
         # Arrange (Given)
         runner = CliRunner()
-        dataset = _clean_dataset()
 
         # Act (When)
         # CliRunner は TTY 非接続のため JSON 出力になる (AC-14-03b)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(main, ["test/clean-dataset"])
+        result = runner.invoke(main, [clean_dataset_path])
 
         # Assert (Then)
         assert result.exit_code == 0
@@ -149,7 +78,7 @@ class TestCliExitCodesOnIssues:
     Source: docs/design.md — CLI 受入条件 AC-14-01b
     """
 
-    def test_warning_issues_exit_code_1(self):
+    def test_warning_issues_exit_code_1(self, warning_dataset_path):
         """
         AC-14-01b: WARNING のみ含むデータセット → 終了コード 1
 
@@ -159,11 +88,9 @@ class TestCliExitCodesOnIssues:
         """
         # Arrange (Given)
         runner = CliRunner()
-        dataset = _dataset_with_warnings()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(main, ["test/warning-dataset"])
+        result = runner.invoke(main, [warning_dataset_path])
 
         # Assert (Then)
         assert result.exit_code == 1, (
@@ -171,7 +98,7 @@ class TestCliExitCodesOnIssues:
             f"Output:\n{result.output}"
         )
 
-    def test_error_issues_exit_code_2(self):
+    def test_error_issues_exit_code_2(self, error_dataset_path):
         """
         AC-14-01b: ERROR を含むデータセット → 終了コード 2
 
@@ -181,11 +108,9 @@ class TestCliExitCodesOnIssues:
         """
         # Arrange (Given)
         runner = CliRunner()
-        dataset = _dataset_with_errors()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(main, ["test/error-dataset"])
+        result = runner.invoke(main, [error_dataset_path])
 
         # Assert (Then)
         assert result.exit_code == 2, (
@@ -246,7 +171,7 @@ class TestCliJsonOutput:
     Source: docs/design.md — CLI 受入条件 AC-14-03, AC-13-02
     """
 
-    def test_json_output_is_valid_json(self):
+    def test_json_output_is_valid_json(self, clean_dataset_path):
         """
         AC-14-03: --output json でのマシン可読出力
 
@@ -256,11 +181,9 @@ class TestCliJsonOutput:
         """
         # Arrange (Given)
         runner = CliRunner()
-        dataset = _clean_dataset()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(main, ["test/dataset", "--output", "json"])
+        result = runner.invoke(main, [clean_dataset_path, "--output", "json"])
 
         # Assert (Then)
         # JSON として parse できること
@@ -272,7 +195,7 @@ class TestCliJsonOutput:
             )
         assert output_data is not None
 
-    def test_json_output_contains_summary_and_results_keys(self):
+    def test_json_output_contains_summary_and_results_keys(self, warning_dataset_path):
         """
         AC-13-02: --output json での summary / results キー
 
@@ -282,11 +205,9 @@ class TestCliJsonOutput:
         """
         # Arrange (Given)
         runner = CliRunner()
-        dataset = _dataset_with_warnings()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(main, ["test/dataset", "--output", "json"])
+        result = runner.invoke(main, [warning_dataset_path, "--output", "json"])
 
         # Assert (Then)
         output_data = json.loads(result.output)
@@ -297,7 +218,7 @@ class TestCliJsonOutput:
             f"'results' key not found in JSON output: {output_data}"
         )
 
-    def test_json_output_exit_code_follows_issue_severity(self):
+    def test_json_output_exit_code_follows_issue_severity(self, warning_dataset_path):
         """
         AC-14-03: --output json 時の exit code は問題の有無に応じて 0/1/2
 
@@ -307,11 +228,9 @@ class TestCliJsonOutput:
         """
         # Arrange (Given)
         runner = CliRunner()
-        dataset = _dataset_with_warnings()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(main, ["test/dataset", "--output", "json"])
+        result = runner.invoke(main, [warning_dataset_path, "--output", "json"])
 
         # Assert (Then)
         assert result.exit_code == 1, (
@@ -330,7 +249,7 @@ class TestCliTtyAutoJsonOutput:
     Source: docs/design.md — CLI 受入条件 AC-14-03b
     """
 
-    def test_non_tty_outputs_json_without_flag(self):
+    def test_non_tty_outputs_json_without_flag(self, clean_dataset_path):
         """
         AC-14-03b: TTY 非接続時の自動 JSON 出力
 
@@ -341,11 +260,9 @@ class TestCliTtyAutoJsonOutput:
         # Arrange (Given)
         # CliRunner はデフォルトで TTY 非接続（is_tty=False）
         runner = CliRunner()
-        dataset = _clean_dataset()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(main, ["test/dataset"])
+        result = runner.invoke(main, [clean_dataset_path])
 
         # Assert (Then)
         try:
@@ -368,7 +285,7 @@ class TestCliSampleSize:
     Source: docs/design.md — CLI 受入条件 AC-14-04
     """
 
-    def test_sample_size_limits_checked_rows(self):
+    def test_sample_size_limits_checked_rows(self, large_dataset_path):
         """
         AC-14-04: --sample-size によるサンプリング
 
@@ -376,30 +293,15 @@ class TestCliSampleSize:
         When: evaldataset <DATASET_ID> --sample-size 100 を実行する
         Then: 100 件のサブセットに対してチェックが実行され、
               JSON 出力の total_rows が 100 である
-
-        Note: CLI は load_hf_dataset に CheckerConfig(sample_size=100) を渡す。
-        load_hf_dataset がサンプリングを担当するため、モックは
-        config.sample_size を読み取って適切なサイズのデータセットを返す。
         """
         # Arrange (Given)
         runner = CliRunner()
 
-        def mock_load_with_sampling(dataset_id, **kwargs):
-            config = kwargs.get("config")
-            n = config.sample_size if (config and config.sample_size) else 1000
-            return Dataset.from_dict({
-                "text": [
-                    f"Unique document {i}: sufficient length text for quality checking purposes."
-                    for i in range(n)
-                ]
-            })
-
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", side_effect=mock_load_with_sampling):
-            result = runner.invoke(
-                main,
-                ["test/large-dataset", "--sample-size", "100", "--output", "json"],
-            )
+        result = runner.invoke(
+            main,
+            [large_dataset_path, "--sample-size", "100", "--output", "json"],
+        )
 
         # Assert (Then)
         assert result.exit_code in (0, 1, 2), (
@@ -427,7 +329,7 @@ class TestCliDryRun:
     Source: docs/design.md — CLI 受入条件 AC-14-05
     """
 
-    def test_dry_run_does_not_write_files(self):
+    def test_dry_run_does_not_write_files(self, html_control_chars_dataset_path):
         """
         AC-14-05: --dry-run での変更なし確認
 
@@ -437,22 +339,20 @@ class TestCliDryRun:
         """
         # Arrange (Given)
         runner = CliRunner()
-        dataset = _dataset_with_html_and_control_chars()
 
         with tempfile.TemporaryDirectory() as tmpdir:
             fix_output_path = os.path.join(tmpdir, "fixed_dataset")
 
             # Act (When)
-            with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-                result = runner.invoke(
-                    main,
-                    [
-                        "test/dataset",
-                        "--fix",
-                        "--dry-run",
-                        "--fix-output", fix_output_path,
-                    ],
-                )
+            result = runner.invoke(
+                main,
+                [
+                    html_control_chars_dataset_path,
+                    "--fix",
+                    "--dry-run",
+                    "--fix-output", fix_output_path,
+                ],
+            )
 
             # Assert (Then)
             # --dry-run なので fix_output_path にファイルが書き込まれない
@@ -465,7 +365,7 @@ class TestCliDryRun:
                 f"Output:\n{result.output}"
             )
 
-    def test_dry_run_outputs_fix_targets(self):
+    def test_dry_run_outputs_fix_targets(self, html_control_chars_dataset_path):
         """
         AC-14-05: --dry-run — 修正対象レコード一覧が出力される
 
@@ -475,14 +375,12 @@ class TestCliDryRun:
         """
         # Arrange (Given)
         runner = CliRunner()
-        dataset = _dataset_with_html_and_control_chars()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(
-                main,
-                ["test/dataset", "--fix", "--dry-run"],
-            )
+        result = runner.invoke(
+            main,
+            [html_control_chars_dataset_path, "--fix", "--dry-run"],
+        )
 
         # Assert (Then)
         assert result.output is not None and len(result.output) > 0, (
@@ -558,7 +456,7 @@ class TestCliRichOutput:
     Source: docs/design.md — レポート受入条件 AC-13-03
     """
 
-    def test_rich_output_flag_produces_output(self):
+    def test_rich_output_flag_produces_output(self, warning_dataset_path):
         """
         AC-13-03: リッチコンソール出力（--output rich 明示指定）
 
@@ -573,15 +471,13 @@ class TestCliRichOutput:
         """
         # Arrange (Given)
         runner = CliRunner()
-        dataset = _dataset_with_warnings()
 
         # Act (When)
-        with patch("evaldataset.cli.load_hf_dataset", return_value=dataset):
-            result = runner.invoke(
-                main,
-                ["test/dataset", "--output", "rich"],
-                color=False,
-            )
+        result = runner.invoke(
+            main,
+            [warning_dataset_path, "--output", "rich"],
+            color=False,
+        )
 
         # Assert (Then)
         # 何らかの出力が生成されること


### PR DESCRIPTION
## Summary
- CLI系IT 16箇所の正常系から `patch("evaldataset.cli.load_hf_dataset")` を除去
- `tests/integration/conftest.py` に8つのフィクスチャを新規作成（ローカルParquetデータセット）
- 異常系テスト（`test_nonexistent_dataset_exits_3`）のモックは `docs/mock-policy.md` 許可範囲のため維持
- AC-14-04 のsample_sizeテストをspec通り（1,000件以上 / --sample-size 100）に修正

## Test plan
- [x] `uv run pytest tests/ -v` — 415 tests passed
- [x] 正常系テストにモック未使用を確認
- [x] code-reviewer: Major/Minor指摘なし
- [x] it-validator: Major-1（sample_size件数）を修正済み

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)