### PR TITLE
--fix / --dry-run で修正前後のチェック結果を表示

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -410,6 +410,29 @@ TextCleaner を先に適用することで、クリーニングで解消され�
 
 ---
 
+#### 修正前後レポート
+
+**目的**: `--fix` / `--dry-run` 実行時に、修正前後のチェック結果を表示し改善度を可視化する。
+
+**受入条件**:
+
+- AC-17-01: `--fix --output json` で修正前後レポートが出力される
+  - Given: WARNING を含む Dataset と `--fix --fix-output <PATH> --output json` オプション
+  - When: CLI を実行する
+  - Then: JSON 出力に `before`（修正前サマリー・結果）と `after`（修正後サマリー・結果）が含まれ、`after.summary.warnings` が `before.summary.warnings` 以下である
+
+- AC-17-02: `--dry-run --output json` で修正前後レポートが出力される
+  - Given: WARNING を含む Dataset と `--fix --dry-run --output json` オプション
+  - When: CLI を実行する
+  - Then: JSON 出力に `before` と `after` が含まれ、ファイル出力は行われない
+
+- AC-17-03: `--fix` で Rich 修正前後レポートが表示される
+  - Given: WARNING を含む Dataset と `--fix --fix-output <PATH>` オプション（`--output` 未指定）
+  - When: CLI を実行する
+  - Then: コンソールに修正前と修正後のサマリーが表示され、改善された項目が確認できる
+
+---
+
 ### レポート出力
 
 ---

--- a/src/evaldataset/cli.py
+++ b/src/evaldataset/cli.py
@@ -220,8 +220,8 @@ def main(
     # --- Run checker pipeline ---
     results = _run_checkers(dataset, text_field, config)
 
-    # --- Build report ---
-    report = Report(
+    # --- Build report (before fix) ---
+    before_report = Report(
         dataset_id=dataset_id,
         split=split,
         total_rows=len(dataset),
@@ -231,19 +231,31 @@ def main(
 
     # --- Fix pipeline (optional) ---
     fix_stats: dict[str, Any] | None = None
+    after_report: Report | None = None
     if fix or dry_run:
-        fix_stats = _run_fix_pipeline(
-            dataset, text_field, config, fix_output, dry_run, is_json
+        fix_stats, after_report = _run_fix_pipeline(
+            dataset,
+            text_field,
+            config,
+            fix_output,
+            dry_run,
+            is_json,
+            dataset_id=dataset_id,
+            split=split,
         )
 
     # --- Render report ---
     if is_json:
-        JsonReporter().render(report, fix_stats=fix_stats)
+        JsonReporter().render(
+            before_report, fix_stats=fix_stats, after_report=after_report
+        )
     else:
-        RichReporter().render(report, fix_stats=fix_stats)
+        RichReporter().render(
+            before_report, fix_stats=fix_stats, after_report=after_report
+        )
 
     # --- Determine exit code ---
-    exit_code = _exit_code_from_report(report)
+    exit_code = _exit_code_from_report(before_report)
     raise SystemExit(exit_code)
 
 
@@ -280,7 +292,10 @@ def _run_fix_pipeline(
     fix_output: str | None,
     dry_run: bool,
     is_json: bool,
-) -> dict[str, Any]:
+    *,
+    dataset_id: str = "",
+    split: str = "train",
+) -> tuple[dict[str, Any], Report]:
     """Run the full fix pipeline: TextCleaner -> checkers -> RowFilter.
 
     Pipeline steps:
@@ -288,9 +303,16 @@ def _run_fix_pipeline(
        chars, whitespace).
     2. Re-run checkers on the cleaned dataset to get fresh results.
     3. RowFilter: remove problem rows based on checker results.
+    4. Re-run checkers on the filtered dataset to produce ``after_report``.
 
     In ``--dry-run`` mode the pipeline reports what would change but does
     not write the output.
+
+    Returns
+    -------
+    tuple[dict[str, Any], Report]
+        ``(fix_stats, after_report)`` where *after_report* is the quality
+        check report for the post-fix dataset.
     """
     # Step 1: TextCleaner (text transformations)
     cleaner = TextCleaner()
@@ -311,6 +333,16 @@ def _run_fix_pipeline(
         skip_checkers=config.skip_checkers,
     )
 
+    # Step 4: Run checkers on filtered dataset to produce after_report
+    after_results = _run_checkers(filtered_dataset, text_field, config)
+    after_report = Report(
+        dataset_id=dataset_id,
+        split=split,
+        total_rows=len(filtered_dataset),
+        text_field=text_field,
+        results=after_results,
+    )
+
     # Merge clean_stats and filter_stats into a combined stats dict
     stats: dict[str, Any] = {**clean_stats, "filter_stats": filter_stats}
 
@@ -325,7 +357,7 @@ def _run_fix_pipeline(
                 f"would be modified, {filter_stats['total_rows_removed']} rows "
                 f"would be removed."
             )
-        return stats
+        return stats, after_report
 
     # Actually write the fixed dataset
     if fix_output:
@@ -344,7 +376,7 @@ def _run_fix_pipeline(
                 f"\n[bold green]Fixed dataset saved to:[/bold green] {fix_output}"
             )
 
-    return stats
+    return stats, after_report
 
 
 def _exit_code_from_report(report: Report) -> int:

--- a/src/evaldataset/report/json_reporter.py
+++ b/src/evaldataset/report/json_reporter.py
@@ -19,19 +19,54 @@ class JsonReporter:
     def __init__(self, stream: IO[str] | None = None) -> None:
         self._stream = stream or sys.stdout
 
-    def render(self, report: Report, fix_stats: dict[str, Any] | None = None) -> None:
+    def render(
+        self,
+        report: Report,
+        fix_stats: dict[str, Any] | None = None,
+        after_report: Report | None = None,
+    ) -> None:
         """Write the report as formatted JSON to the output stream.
+
+        When *after_report* is provided (i.e. ``--fix`` or ``--dry-run``),
+        the output uses a ``before`` / ``after`` structure.  Otherwise the
+        output is backward-compatible with the flat structure.
 
         Parameters
         ----------
         report:
-            The aggregated quality check report.
+            The aggregated quality check report (before fix, or the only
+            report when no fix is applied).
         fix_stats:
-            Optional statistics from the TextCleaner fix pipeline.
+            Optional statistics from the fix pipeline.
+        after_report:
+            Optional post-fix quality check report.  When present the
+            JSON output uses the ``before`` / ``after`` envelope.
         """
-        data = report.to_dict()
-        if fix_stats is not None:
-            data["fix_stats"] = fix_stats
+        if after_report is not None:
+            # --fix / --dry-run: before/after structure
+            before_dict = report.to_dict()
+            after_dict = after_report.to_dict()
+            data: dict[str, Any] = {
+                "dataset_id": report.dataset_id,
+                "split": report.split,
+                "total_rows": report.total_rows,
+                "text_field": report.text_field,
+                "before": {
+                    "summary": before_dict["summary"],
+                    "results": before_dict["results"],
+                },
+            }
+            if fix_stats is not None:
+                data["fix_stats"] = fix_stats
+            data["after"] = {
+                "summary": after_dict["summary"],
+                "results": after_dict["results"],
+            }
+        else:
+            # No fix: backward-compatible flat structure
+            data = report.to_dict()
+            if fix_stats is not None:
+                data["fix_stats"] = fix_stats
         self._stream.write(json.dumps(data, ensure_ascii=False, indent=2))
         self._stream.write("\n")
 

--- a/src/evaldataset/report/rich_reporter.py
+++ b/src/evaldataset/report/rich_reporter.py
@@ -22,22 +22,40 @@ class RichReporter:
     def __init__(self, console: Console | None = None) -> None:
         self._console = console or Console()
 
-    def render(self, report: Report, fix_stats: dict[str, Any] | None = None) -> None:
+    def render(
+        self,
+        report: Report,
+        fix_stats: dict[str, Any] | None = None,
+        after_report: Report | None = None,
+    ) -> None:
         """Print the report to the console using Rich formatting.
+
+        When *after_report* is provided (``--fix`` or ``--dry-run``),
+        a before/after comparison is rendered.  Otherwise the output is
+        backward-compatible with the single-report layout.
 
         Parameters
         ----------
         report:
-            The aggregated quality check report.
+            The aggregated quality check report (before fix, or the only
+            report when no fix is applied).
         fix_stats:
-            Optional statistics from the TextCleaner fix pipeline.
+            Optional statistics from the fix pipeline.
+        after_report:
+            Optional post-fix quality check report.
         """
         self._render_header(report)
-        self._render_results_table(report)
-        self._render_issues_detail(report)
-        if fix_stats is not None:
-            self._render_fix_stats(fix_stats)
-        self._render_summary(report)
+
+        if after_report is not None:
+            # --fix / --dry-run: before → fix applied → after
+            self._render_before_after(report, fix_stats, after_report)
+        else:
+            # No fix: original single-report layout
+            self._render_results_table(report)
+            self._render_issues_detail(report)
+            if fix_stats is not None:
+                self._render_fix_stats(fix_stats)
+            self._render_summary(report)
 
     def render_error(self, message: str) -> None:
         """Print an error message to stderr via Rich console.
@@ -148,6 +166,70 @@ class RichReporter:
         self._console.print(
             Panel(summary_text, title=f"[bold {style}]{verdict}[/bold {style}]")
         )
+
+    def _render_before_after(
+        self,
+        before_report: Report,
+        fix_stats: dict[str, Any] | None,
+        after_report: Report,
+    ) -> None:
+        """Render before/after fix comparison (AC-17-03).
+
+        Shows three sections:
+        - Before Fix: issue summary from the original dataset
+        - Fix Applied: cleaning and filtering statistics
+        - After Fix: issue summary from the fixed dataset
+        """
+        # --- Before Fix ---
+        self._console.print()
+        self._console.rule("[bold]Before Fix[/bold]")
+        self._console.print(
+            f"  Issues: {before_report.total_issues} "
+            f"({before_report.total_errors} errors, "
+            f"{before_report.total_warnings} warnings)"
+        )
+        self._render_results_table(before_report)
+        self._render_issues_detail(before_report)
+
+        # --- Fix Applied ---
+        self._console.print()
+        self._console.rule("[bold]Fix Applied[/bold]")
+        if fix_stats is not None:
+            total_fixed = fix_stats.get("total_fixed", 0)
+            self._console.print(f"  Text cleaned: {total_fixed} rows")
+
+            filter_stats = fix_stats.get("filter_stats")
+            if filter_stats is not None:
+                total_removed = filter_stats.get("total_rows_removed", 0)
+                rows_after = filter_stats.get("rows_after_filter", "?")
+
+                # Build per-checker breakdown (exclude aggregate keys)
+                _AGGREGATE_KEYS = {"total_rows_removed", "rows_after_filter"}
+                parts: list[str] = []
+                for key, count in filter_stats.items():
+                    if key in _AGGREGATE_KEYS:
+                        continue
+                    if isinstance(count, int) and count > 0:
+                        parts.append(f"{count} {key}")
+
+                breakdown = ", ".join(parts) if parts else "none"
+                self._console.print(
+                    f"  Rows removed: {total_removed} ({breakdown})"
+                )
+                self._console.print(f"  Rows remaining: {rows_after}")
+
+        # --- After Fix ---
+        self._console.print()
+        self._console.rule("[bold]After Fix[/bold]")
+        self._console.print(
+            f"  Rows: {after_report.total_rows:,} | "
+            f"Issues: {after_report.total_issues} "
+            f"({after_report.total_errors} errors, "
+            f"{after_report.total_warnings} warnings)"
+        )
+        self._render_results_table(after_report)
+        self._render_issues_detail(after_report)
+        self._render_summary(after_report)
 
 
 def _severity_style(severity: Severity) -> str:

--- a/tests/integration/test_fix_report_integration.py
+++ b/tests/integration/test_fix_report_integration.py
@@ -1,0 +1,570 @@
+"""Integration tests for fix before/after report via CLI.
+
+IT: 修正前後レポート
+Source: docs/design.md — 修正前後レポート 受入条件 (AC-17-01, AC-17-02, AC-17-03)
+
+修正前後レポートは `--fix` / `--dry-run` 実行時に、修正前後のチェック結果を
+表示し改善度を可視化する。
+
+テスト方法:
+- CliRunner + isolated_filesystem() でカレントディレクトリを制御する
+  (--fix-output は CWD 内のパスのみ許可されるため)
+- `--output json` で JSON 出力を取得し before / after 構造を検証する
+- WARNING を含むデータセット: 短文テキスト（min_length=50 未満）1 件
+  + 正常テキスト 2 件（各テキストはユニーク・重複なし）
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from click.testing import CliRunner
+from datasets import Dataset, disable_progress_bars
+
+from evaldataset.cli import main
+
+# Suppress HuggingFace progress bars in test output.
+disable_progress_bars()
+
+# ---------------------------------------------------------------------------
+# Shared text constants
+# ---------------------------------------------------------------------------
+
+# 短文テキスト: min_length=50 未満 → TextLengthChecker が WARNING を検出する
+_SHORT_TEXT = "Short text."
+
+# 正常テキスト: min_length=50 以上、互いに内容が異なりユニーク
+_NORMAL_TEXT_A = (
+    "Machine learning algorithms process large amounts of data efficiently "
+    "and enable computers to learn patterns from experience without explicit programming."
+)
+_NORMAL_TEXT_B = (
+    "Natural language processing enables computers to understand and generate "
+    "human language, transforming how we interact with technology every day."
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_parquet_dataset(ds: Dataset, base_dir: str, subdir: str = "input") -> str:
+    """Persist *ds* as Parquet inside *base_dir/<subdir>/data/* and return the
+    relative data path (relative to *base_dir*).
+
+    The relative path is used as DATASET_ID for CLI invocation inside
+    isolated_filesystem(), where CWD == base_dir.
+    """
+    data_dir = os.path.join(base_dir, subdir, "data")
+    os.makedirs(data_dir, exist_ok=True)
+    ds.to_parquet(os.path.join(data_dir, "train-00000-of-00001.parquet"))
+    return os.path.join(subdir, "data")
+
+
+# ---------------------------------------------------------------------------
+# AC-17-01: --fix --output json で修正前後レポートが出力される
+# ---------------------------------------------------------------------------
+
+
+class TestFixReportJson:
+    """
+    IT: 修正前後レポート — --fix --output json
+    Source: docs/design.md — 修正前後レポート 受入条件 AC-17-01
+    """
+
+    def test_fix_json_output_contains_before_and_after_keys(self):
+        """
+        AC-17-01: --fix --output json で修正前後レポートが出力される（before/after キー）
+
+        Given: WARNING を含む Dataset（短文テキスト 1 件 + 正常テキスト 2 件）と
+               --fix --fix-output <PATH> --output json オプション
+        When: CLI を実行する
+        Then: JSON 出力に before と after キーが含まれる
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [dataset_path, "--fix", "--fix-output", fix_dir, "--output", "json"],
+            )
+
+            # Assert (Then)
+            assert result.exit_code in (0, 1, 2), (
+                f"Unexpected exit code {result.exit_code}. Output:\n{result.output}"
+            )
+            output_data = json.loads(result.output)
+
+            assert "before" in output_data, (
+                f"'before' key not found in JSON output: {list(output_data.keys())}"
+            )
+            assert "after" in output_data, (
+                f"'after' key not found in JSON output: {list(output_data.keys())}"
+            )
+
+    def test_fix_json_before_has_warnings(self):
+        """
+        AC-17-01: 修正前 before.summary.warnings が 0 より大きい
+
+        Given: WARNING を含む Dataset（短文テキスト 1 件 + 正常テキスト 2 件）と
+               --fix --fix-output <PATH> --output json オプション
+        When: CLI を実行する
+        Then: before.summary.warnings > 0 である
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [dataset_path, "--fix", "--fix-output", fix_dir, "--output", "json"],
+            )
+
+            # Assert (Then)
+            output_data = json.loads(result.output)
+            before = output_data.get("before", {})
+            before_summary = before.get("summary", {})
+            before_warnings = before_summary.get("warnings", 0)
+
+            assert before_warnings > 0, (
+                f"Expected before.summary.warnings > 0 for dataset with short text, "
+                f"got {before_warnings}. before.summary: {before_summary}"
+            )
+
+    def test_fix_json_after_warnings_le_before_warnings(self):
+        """
+        AC-17-01: 修正後 after.summary.warnings が修正前以下である
+
+        Given: WARNING を含む Dataset（短文テキスト 1 件 + 正常テキスト 2 件）と
+               --fix --fix-output <PATH> --output json オプション
+        When: CLI を実行する
+        Then: after.summary.warnings <= before.summary.warnings である
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [dataset_path, "--fix", "--fix-output", fix_dir, "--output", "json"],
+            )
+
+            # Assert (Then)
+            output_data = json.loads(result.output)
+            before_warnings = output_data["before"]["summary"].get("warnings", 0)
+            after_warnings = output_data["after"]["summary"].get("warnings", 0)
+
+            assert after_warnings <= before_warnings, (
+                f"Expected after.summary.warnings ({after_warnings}) <= "
+                f"before.summary.warnings ({before_warnings})"
+            )
+
+    def test_fix_json_output_contains_fix_stats(self):
+        """
+        AC-17-01: JSON 出力に fix_stats キーが存在する
+
+        Given: WARNING を含む Dataset と --fix --fix-output <PATH> --output json オプション
+        When: CLI を実行する
+        Then: JSON 出力に fix_stats キーが含まれる
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [dataset_path, "--fix", "--fix-output", fix_dir, "--output", "json"],
+            )
+
+            # Assert (Then)
+            output_data = json.loads(result.output)
+            assert "fix_stats" in output_data, (
+                f"'fix_stats' key not found in JSON output: {list(output_data.keys())}"
+            )
+
+    def test_fix_json_before_has_results_key(self):
+        """
+        AC-17-01: before オブジェクトに results キーが含まれる
+
+        Given: WARNING を含む Dataset と --fix --fix-output <PATH> --output json オプション
+        When: CLI を実行する
+        Then: before.results が存在する
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [dataset_path, "--fix", "--fix-output", fix_dir, "--output", "json"],
+            )
+
+            # Assert (Then)
+            output_data = json.loads(result.output)
+            before = output_data.get("before", {})
+            assert "results" in before, (
+                f"'results' key not found in before: {list(before.keys())}"
+            )
+
+    def test_fix_json_after_has_results_key(self):
+        """
+        AC-17-01: after オブジェクトに results キーが含まれる
+
+        Given: WARNING を含む Dataset と --fix --fix-output <PATH> --output json オプション
+        When: CLI を実行する
+        Then: after.results が存在する
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [dataset_path, "--fix", "--fix-output", fix_dir, "--output", "json"],
+            )
+
+            # Assert (Then)
+            output_data = json.loads(result.output)
+            after = output_data.get("after", {})
+            assert "results" in after, (
+                f"'results' key not found in after: {list(after.keys())}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# AC-17-02: --dry-run --output json で修正前後レポートが出力される
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunReportJson:
+    """
+    IT: 修正前後レポート — --fix --dry-run --output json
+    Source: docs/design.md — 修正前後レポート 受入条件 AC-17-02
+    """
+
+    def test_dry_run_json_output_contains_before_and_after_keys(self):
+        """
+        AC-17-02: --dry-run --output json で修正前後レポートが出力される（before/after キー）
+
+        Given: WARNING を含む Dataset（短文テキスト 1 件 + 正常テキスト 2 件）と
+               --fix --dry-run --output json オプション
+        When: CLI を実行する
+        Then: JSON 出力に before と after キーが含まれる
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [
+                    dataset_path,
+                    "--fix",
+                    "--dry-run",
+                    "--fix-output", fix_dir,
+                    "--output", "json",
+                ],
+            )
+
+            # Assert (Then)
+            assert result.exit_code in (0, 1, 2), (
+                f"Unexpected exit code {result.exit_code}. Output:\n{result.output}"
+            )
+            output_data = json.loads(result.output)
+
+            assert "before" in output_data, (
+                f"'before' key not found in JSON output: {list(output_data.keys())}"
+            )
+            assert "after" in output_data, (
+                f"'after' key not found in JSON output: {list(output_data.keys())}"
+            )
+
+    def test_dry_run_does_not_write_fix_output_file(self):
+        """
+        AC-17-02: --dry-run 時にファイル出力は行われない
+
+        Given: WARNING を含む Dataset と --fix --dry-run --output json オプション
+        When: CLI を実行する
+        Then: --fix-output で指定したパスにファイルが作成されていない
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output_dry_run"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [
+                    dataset_path,
+                    "--fix",
+                    "--dry-run",
+                    "--fix-output", fix_dir,
+                    "--output", "json",
+                ],
+            )
+
+            # Assert (Then)
+            assert result.exit_code in (0, 1, 2), (
+                f"Unexpected exit code {result.exit_code}. Output:\n{result.output}"
+            )
+            assert not os.path.exists(fix_dir), (
+                f"--dry-run should not write files, but '{fix_dir}' was created"
+            )
+
+    def test_dry_run_json_before_has_summary(self):
+        """
+        AC-17-02: --dry-run JSON 出力の before に summary が含まれる
+
+        Given: WARNING を含む Dataset と --fix --dry-run --output json オプション
+        When: CLI を実行する
+        Then: before.summary が存在する
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output_dry_run"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [
+                    dataset_path,
+                    "--fix",
+                    "--dry-run",
+                    "--fix-output", fix_dir,
+                    "--output", "json",
+                ],
+            )
+
+            # Assert (Then)
+            output_data = json.loads(result.output)
+            before = output_data.get("before", {})
+            assert "summary" in before, (
+                f"'summary' not found in before: {list(before.keys())}"
+            )
+
+    def test_dry_run_json_after_has_summary(self):
+        """
+        AC-17-02: --dry-run JSON 出力の after に summary が含まれる
+
+        Given: WARNING を含む Dataset と --fix --dry-run --output json オプション
+        When: CLI を実行する
+        Then: after.summary が存在する
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output_dry_run"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [
+                    dataset_path,
+                    "--fix",
+                    "--dry-run",
+                    "--fix-output", fix_dir,
+                    "--output", "json",
+                ],
+            )
+
+            # Assert (Then)
+            output_data = json.loads(result.output)
+            after = output_data.get("after", {})
+            assert "summary" in after, (
+                f"'summary' not found in after: {list(after.keys())}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# AC-17-03: --fix で Rich 修正前後レポートが表示される
+# ---------------------------------------------------------------------------
+
+
+class TestFixReportRich:
+    """
+    IT: 修正前後レポート — --fix Rich コンソール出力
+    Source: docs/design.md — 修正前後レポート 受入条件 AC-17-03
+    """
+
+    def test_fix_rich_output_contains_before_section(self):
+        """
+        AC-17-03: --fix で Rich 修正前後レポートが表示される（Before セクション）
+
+        Given: WARNING を含む Dataset（短文テキスト 1 件 + 正常テキスト 2 件）と
+               --fix --fix-output <PATH> オプション（--output 未指定）
+        When: CLI を実行する
+        Then: コンソール出力に修正前（Before）のサマリーが含まれる
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output"
+
+            # Act (When)
+            # --output 未指定 (TTY 非接続時は自動 JSON、--output rich 明示で Rich 出力)
+            result = runner.invoke(
+                main,
+                [dataset_path, "--fix", "--fix-output", fix_dir, "--output", "rich"],
+                color=False,
+            )
+
+            # Assert (Then)
+            assert result.exit_code in (0, 1, 2), (
+                f"Unexpected exit code {result.exit_code}. Output:\n{result.output}"
+            )
+            assert result.output is not None and len(result.output.strip()) > 0, (
+                "--fix --output rich should produce some output"
+            )
+            # 修正前（Before）に関する表示が含まれること
+            assert "before" in result.output.lower() or "Before" in result.output, (
+                f"Expected 'before' or 'Before' in Rich output, got:\n{result.output}"
+            )
+
+    def test_fix_rich_output_contains_after_section(self):
+        """
+        AC-17-03: --fix で Rich 修正前後レポートが表示される（After セクション）
+
+        Given: WARNING を含む Dataset（短文テキスト 1 件 + 正常テキスト 2 件）と
+               --fix --fix-output <PATH> オプション（--output 未指定）
+        When: CLI を実行する
+        Then: コンソール出力に修正後（After）のサマリーが含まれる
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [dataset_path, "--fix", "--fix-output", fix_dir, "--output", "rich"],
+                color=False,
+            )
+
+            # Assert (Then)
+            assert result.exit_code in (0, 1, 2), (
+                f"Unexpected exit code {result.exit_code}. Output:\n{result.output}"
+            )
+            # 修正後（After）に関する表示が含まれること
+            assert "after" in result.output.lower() or "After" in result.output, (
+                f"Expected 'after' or 'After' in Rich output, got:\n{result.output}"
+            )
+
+    def test_fix_rich_output_shows_improvement(self):
+        """
+        AC-17-03: --fix Rich 出力に改善された項目が確認できる
+
+        Given: WARNING を含む Dataset（短文テキスト 1 件 + 正常テキスト 2 件）と
+               --fix --fix-output <PATH> オプション（--output rich 指定）
+        When: CLI を実行する
+        Then: コンソール出力が生成され、修正の前後に関する情報が含まれる
+        """
+        # Arrange (Given)
+        runner = CliRunner()
+        ds = Dataset.from_dict({
+            "text": [_SHORT_TEXT, _NORMAL_TEXT_A, _NORMAL_TEXT_B]
+        })
+
+        with runner.isolated_filesystem():
+            dataset_path = _make_parquet_dataset(ds, os.getcwd())
+            fix_dir = "fixed_output"
+
+            # Act (When)
+            result = runner.invoke(
+                main,
+                [dataset_path, "--fix", "--fix-output", fix_dir, "--output", "rich"],
+                color=False,
+            )
+
+            # Assert (Then)
+            assert result.exit_code in (0, 1, 2), (
+                f"Unexpected exit code {result.exit_code}. Output:\n{result.output}"
+            )
+            # Before と After の両方のキーワードが出力中に存在すること
+            output_lower = result.output.lower()
+            has_before = "before" in output_lower
+            has_after = "after" in output_lower
+            assert has_before and has_after, (
+                f"Expected both 'before' and 'after' in Rich output. "
+                f"has_before={has_before}, has_after={has_after}. "
+                f"Output:\n{result.output}"
+            )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1311,3 +1311,291 @@ class TestCliHelpers:
 
         config = _build_config(str(config_file), None, [])
         assert config.min_length == 200
+
+
+# ---------------------------------------------------------------------------
+# AC-17: --fix / --dry-run 修正前後レポートの CLI テスト
+# ---------------------------------------------------------------------------
+
+
+def _make_after_report(
+    dataset_id: str = "test/dataset",
+    total_rows: int = 2,
+    results: list | None = None,
+) -> "Report":
+    """修正後レポートのファクトリ。"""
+    from evaldataset.models import Report
+
+    return Report(
+        dataset_id=dataset_id,
+        split="train",
+        total_rows=total_rows,
+        text_field="text",
+        results=results or [],
+    )
+
+
+def _make_fix_stats(
+    total_fixed: int = 1,
+    total_rows: int = 3,
+    rows_removed: int = 1,
+) -> dict:
+    """fix_stats ディクショナリのファクトリ。"""
+    return {
+        "total_rows": total_rows,
+        "total_fixed": total_fixed,
+        "mojibake_fixed": 0,
+        "html_stripped": 0,
+        "control_chars_removed": 0,
+        "whitespace_normalized": 0,
+        "filter_stats": {
+            "exact_duplicate": 0,
+            "near_duplicate": 0,
+            "text_length": rows_removed,
+            "pii": 0,
+            "total_rows_removed": rows_removed,
+            "rows_after_filter": total_rows - rows_removed,
+        },
+    }
+
+
+class TestCliFixBeforeAfterReport:
+    """--fix / --dry-run 実行時の修正前後レポート出力テスト。
+
+    Covers:
+    - AC-17-01: --fix --output json で before, after, fix_stats キーが含まれる
+    - AC-17-02: --dry-run --output json で before, after が含まれ、ファイル出力なし
+    - AC-17-03: Rich 表示で修正前後サマリーが表示される（RichReporter は別途 test_reporter.py でテスト）
+    """
+
+    def test_fix_output_json_contains_before_key(self) -> None:
+        """AC-17-01: --fix --output json で JSON 出力に 'before' キーが含まれる。"""
+        from evaldataset.cli import main
+
+        runner = CliRunner()
+        mock_dataset = _make_dataset(["short", "x" * 100, "y" * 100])
+
+        before_checker = MagicMock()
+        before_checker.return_value.check.return_value = _make_check_result(
+            checker_name="text_length",
+            issues=[_make_warning_issue("text_length")],
+        )
+        after_report = _make_after_report(total_rows=2)
+        fix_stats = _make_fix_stats(total_fixed=1, total_rows=3, rows_removed=1)
+
+        with patch("evaldataset.cli.load_hf_dataset", return_value=mock_dataset), \
+             patch("evaldataset.cli.get_all_checkers", return_value={"text_length": before_checker}), \
+             patch("evaldataset.cli._run_fix_pipeline", return_value=(fix_stats, after_report)):
+            result = runner.invoke(
+                main,
+                ["test/dataset", "--fix", "--output", "json"],
+            )
+
+        assert result.exit_code in (0, 1, 2)
+        parsed = json.loads(result.output)
+        assert "before" in parsed
+
+    def test_fix_output_json_contains_after_key(self) -> None:
+        """AC-17-01: --fix --output json で JSON 出力に 'after' キーが含まれる。"""
+        from evaldataset.cli import main
+
+        runner = CliRunner()
+        mock_dataset = _make_dataset(["short", "x" * 100, "y" * 100])
+
+        before_checker = MagicMock()
+        before_checker.return_value.check.return_value = _make_check_result(
+            checker_name="text_length",
+            issues=[_make_warning_issue("text_length")],
+        )
+        after_report = _make_after_report(total_rows=2)
+        fix_stats = _make_fix_stats(total_fixed=1, total_rows=3, rows_removed=1)
+
+        with patch("evaldataset.cli.load_hf_dataset", return_value=mock_dataset), \
+             patch("evaldataset.cli.get_all_checkers", return_value={"text_length": before_checker}), \
+             patch("evaldataset.cli._run_fix_pipeline", return_value=(fix_stats, after_report)):
+            result = runner.invoke(
+                main,
+                ["test/dataset", "--fix", "--output", "json"],
+            )
+
+        assert result.exit_code in (0, 1, 2)
+        parsed = json.loads(result.output)
+        assert "after" in parsed
+
+    def test_fix_output_json_contains_fix_stats_key(self) -> None:
+        """AC-17-01: --fix --output json で JSON 出力に 'fix_stats' キーが含まれる。"""
+        from evaldataset.cli import main
+
+        runner = CliRunner()
+        mock_dataset = _make_dataset(["short", "x" * 100])
+
+        before_checker = MagicMock()
+        before_checker.return_value.check.return_value = _make_check_result(
+            checker_name="text_length",
+            issues=[_make_warning_issue("text_length")],
+        )
+        after_report = _make_after_report(total_rows=1)
+        fix_stats = _make_fix_stats(total_fixed=1, total_rows=2, rows_removed=1)
+
+        with patch("evaldataset.cli.load_hf_dataset", return_value=mock_dataset), \
+             patch("evaldataset.cli.get_all_checkers", return_value={"text_length": before_checker}), \
+             patch("evaldataset.cli._run_fix_pipeline", return_value=(fix_stats, after_report)):
+            result = runner.invoke(
+                main,
+                ["test/dataset", "--fix", "--output", "json"],
+            )
+
+        assert result.exit_code in (0, 1, 2)
+        parsed = json.loads(result.output)
+        assert "fix_stats" in parsed
+
+    def test_fix_without_flag_no_before_after_keys(self) -> None:
+        """AC-17-01: --fix なしの場合、JSON 出力に 'before'/'after' キーが存在しない。"""
+        from evaldataset.cli import main
+
+        runner = CliRunner()
+        mock_dataset = _make_dataset(["x" * 100, "y" * 100])
+
+        with patch("evaldataset.cli.load_hf_dataset", return_value=mock_dataset), \
+             patch("evaldataset.cli.get_all_checkers", return_value={}):
+            result = runner.invoke(main, ["test/dataset", "--output", "json"])
+
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "before" not in parsed
+        assert "after" not in parsed
+
+    def test_fix_without_flag_has_top_level_summary_and_results(self) -> None:
+        """AC-17-01: --fix なしの場合、従来通り top-level に 'summary', 'results' が存在する。"""
+        from evaldataset.cli import main
+
+        runner = CliRunner()
+        mock_dataset = _make_dataset(["x" * 100, "y" * 100])
+
+        with patch("evaldataset.cli.load_hf_dataset", return_value=mock_dataset), \
+             patch("evaldataset.cli.get_all_checkers", return_value={}):
+            result = runner.invoke(main, ["test/dataset", "--output", "json"])
+
+        parsed = json.loads(result.output)
+        assert "summary" in parsed
+        assert "results" in parsed
+
+    def test_fix_after_warnings_lte_before_warnings(self) -> None:
+        """AC-17-01: after.summary.warnings <= before.summary.warnings であること。"""
+        from evaldataset.cli import main
+
+        runner = CliRunner()
+        mock_dataset = _make_dataset(["short", "x" * 100, "y" * 100])
+
+        # before: 1 WARNING
+        before_checker = MagicMock()
+        before_checker.return_value.check.return_value = _make_check_result(
+            checker_name="text_length",
+            issues=[_make_warning_issue("text_length")],
+        )
+        # after_report: WARNING なし（問題行除去済み）
+        after_report = _make_after_report(total_rows=2, results=[])
+        fix_stats = _make_fix_stats(total_fixed=1, total_rows=3, rows_removed=1)
+
+        with patch("evaldataset.cli.load_hf_dataset", return_value=mock_dataset), \
+             patch("evaldataset.cli.get_all_checkers", return_value={"text_length": before_checker}), \
+             patch("evaldataset.cli._run_fix_pipeline", return_value=(fix_stats, after_report)):
+            result = runner.invoke(
+                main,
+                ["test/dataset", "--fix", "--output", "json"],
+            )
+
+        assert result.exit_code in (0, 1, 2)
+        parsed = json.loads(result.output)
+        assert "before" in parsed
+        assert "after" in parsed
+        before_warnings = parsed["before"]["summary"]["warnings"]
+        after_warnings = parsed["after"]["summary"]["warnings"]
+        assert after_warnings <= before_warnings
+
+    def test_dry_run_output_json_contains_before_key(self) -> None:
+        """AC-17-02: --dry-run --output json で JSON 出力に 'before' キーが含まれる。"""
+        from evaldataset.cli import main
+
+        runner = CliRunner()
+        mock_dataset = _make_dataset(["short", "x" * 100])
+
+        before_checker = MagicMock()
+        before_checker.return_value.check.return_value = _make_check_result(
+            checker_name="text_length",
+            issues=[_make_warning_issue("text_length")],
+        )
+        after_report = _make_after_report(total_rows=1)
+        fix_stats = _make_fix_stats(total_fixed=1, total_rows=2, rows_removed=1)
+
+        with patch("evaldataset.cli.load_hf_dataset", return_value=mock_dataset), \
+             patch("evaldataset.cli.get_all_checkers", return_value={"text_length": before_checker}), \
+             patch("evaldataset.cli._run_fix_pipeline", return_value=(fix_stats, after_report)):
+            result = runner.invoke(
+                main,
+                ["test/dataset", "--fix", "--dry-run", "--output", "json"],
+            )
+
+        assert result.exit_code in (0, 1, 2)
+        parsed = json.loads(result.output)
+        assert "before" in parsed
+
+    def test_dry_run_output_json_contains_after_key(self) -> None:
+        """AC-17-02: --dry-run --output json で JSON 出力に 'after' キーが含まれる。"""
+        from evaldataset.cli import main
+
+        runner = CliRunner()
+        mock_dataset = _make_dataset(["short", "x" * 100])
+
+        before_checker = MagicMock()
+        before_checker.return_value.check.return_value = _make_check_result(
+            checker_name="text_length",
+            issues=[_make_warning_issue("text_length")],
+        )
+        after_report = _make_after_report(total_rows=1)
+        fix_stats = _make_fix_stats(total_fixed=1, total_rows=2, rows_removed=1)
+
+        with patch("evaldataset.cli.load_hf_dataset", return_value=mock_dataset), \
+             patch("evaldataset.cli.get_all_checkers", return_value={"text_length": before_checker}), \
+             patch("evaldataset.cli._run_fix_pipeline", return_value=(fix_stats, after_report)):
+            result = runner.invoke(
+                main,
+                ["test/dataset", "--fix", "--dry-run", "--output", "json"],
+            )
+
+        assert result.exit_code in (0, 1, 2)
+        parsed = json.loads(result.output)
+        assert "after" in parsed
+
+    def test_dry_run_does_not_write_file(self) -> None:
+        """AC-17-02: --dry-run では _run_fix_pipeline が dry_run=True で呼ばれる。"""
+        from evaldataset.cli import main
+
+        runner = CliRunner()
+        mock_dataset = _make_dataset(["short", "x" * 100])
+
+        before_checker = MagicMock()
+        before_checker.return_value.check.return_value = _make_check_result(
+            checker_name="text_length",
+            issues=[_make_warning_issue("text_length")],
+        )
+        after_report = _make_after_report(total_rows=1)
+        fix_stats = _make_fix_stats(total_fixed=1, total_rows=2, rows_removed=1)
+
+        with patch("evaldataset.cli.load_hf_dataset", return_value=mock_dataset), \
+             patch("evaldataset.cli.get_all_checkers", return_value={"text_length": before_checker}), \
+             patch("evaldataset.cli._run_fix_pipeline", return_value=(fix_stats, after_report)) \
+             as mock_pipeline:
+            result = runner.invoke(
+                main,
+                ["test/dataset", "--fix", "--dry-run", "--output", "json"],
+            )
+
+        # _run_fix_pipeline は dry_run=True で呼ばれること
+        assert mock_pipeline.called
+        args, kwargs = mock_pipeline.call_args
+        # _run_fix_pipeline のシグネチャ: (dataset, text_field, config, fix_output, dry_run, is_json, *, dataset_id, split)
+        # dry_run は5番目の positional 引数
+        dry_run_arg = args[4] if len(args) > 4 else kwargs.get("dry_run")
+        assert dry_run_arg is True
+        assert result.exit_code in (0, 1, 2)

--- a/tests/unit/test_reporter.py
+++ b/tests/unit/test_reporter.py
@@ -566,3 +566,292 @@ class TestRichReporter:
         err_stream.seek(0)
         output = err_stream.read()
         assert "Custom error message" in output
+
+
+# ---------------------------------------------------------------------------
+# AC-17: 修正前後レポート — JsonReporter
+# ---------------------------------------------------------------------------
+
+
+class TestJsonReporterFixReport:
+    """JsonReporter の修正前後レポート出力テスト。
+
+    AC-17-01: --fix --output json で修正前後レポートが出力される
+    AC-17-02: --dry-run --output json で修正前後レポートが出力される
+    """
+
+    @pytest.fixture
+    def stream(self) -> io.StringIO:
+        """出力キャプチャ用のStringIOストリーム。"""
+        return io.StringIO()
+
+    @pytest.fixture
+    def reporter(self, stream: io.StringIO):
+        """JsonReporter インスタンス（テスト用ストリームを使用）。"""
+        from evaldataset.report import JsonReporter
+        return JsonReporter(stream=stream)
+
+    @pytest.fixture
+    def before_report(self) -> Report:
+        """修正前レポート（WARNINGあり）。"""
+        warning_result = _make_check_result(
+            checker_name="text_length",
+            issues=[
+                _make_issue(
+                    checker="text_length",
+                    severity=Severity.WARNING,
+                    message="Text too short",
+                    row_indices=[0, 1],
+                )
+            ],
+        )
+        return _make_report(total_rows=5, results=[warning_result])
+
+    @pytest.fixture
+    def after_report(self) -> Report:
+        """修正後レポート（問題行除去済み）。"""
+        return _make_report(total_rows=3, results=[])
+
+    def test_render_with_after_report_contains_before_key(
+        self, reporter, stream: io.StringIO, before_report, after_report
+    ) -> None:
+        """AC-17-01: after_report を渡すと JSON 出力に 'before' キーが含まれる。"""
+        fix_stats = {"total_fixed": 1, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        parsed = json.loads(stream.read())
+        assert "before" in parsed
+
+    def test_render_with_after_report_contains_after_key(
+        self, reporter, stream: io.StringIO, before_report, after_report
+    ) -> None:
+        """AC-17-01: after_report を渡すと JSON 出力に 'after' キーが含まれる。"""
+        fix_stats = {"total_fixed": 1, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        parsed = json.loads(stream.read())
+        assert "after" in parsed
+
+    def test_render_with_after_report_before_contains_summary(
+        self, reporter, stream: io.StringIO, before_report, after_report
+    ) -> None:
+        """AC-17-01: 'before' には summary が含まれる。"""
+        fix_stats = {"total_fixed": 1, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        parsed = json.loads(stream.read())
+        assert "summary" in parsed["before"]
+
+    def test_render_with_after_report_after_contains_summary(
+        self, reporter, stream: io.StringIO, before_report, after_report
+    ) -> None:
+        """AC-17-01: 'after' には summary が含まれる。"""
+        fix_stats = {"total_fixed": 1, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        parsed = json.loads(stream.read())
+        assert "summary" in parsed["after"]
+
+    def test_render_with_after_report_before_warnings_gte_after_warnings(
+        self, reporter, stream: io.StringIO, before_report, after_report
+    ) -> None:
+        """AC-17-01: after.summary.warnings <= before.summary.warnings であること。"""
+        fix_stats = {"total_fixed": 1, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        parsed = json.loads(stream.read())
+        before_warnings = parsed["before"]["summary"]["warnings"]
+        after_warnings = parsed["after"]["summary"]["warnings"]
+        assert after_warnings <= before_warnings
+
+    def test_render_with_after_report_contains_fix_stats(
+        self, reporter, stream: io.StringIO, before_report, after_report
+    ) -> None:
+        """AC-17-01: fix_stats も JSON 出力に含まれること。"""
+        fix_stats = {"total_fixed": 2, "filter_stats": {"total_rows_removed": 1}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        parsed = json.loads(stream.read())
+        assert "fix_stats" in parsed
+
+    def test_render_with_after_report_before_reflects_before_report(
+        self, reporter, stream: io.StringIO, before_report, after_report
+    ) -> None:
+        """AC-17-01: before の内容が before_report の to_dict() と一致する。"""
+        fix_stats = {"total_fixed": 1, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        parsed = json.loads(stream.read())
+        expected_before = before_report.to_dict()
+        assert parsed["before"]["summary"] == expected_before["summary"]
+
+    def test_render_with_after_report_after_reflects_after_report(
+        self, reporter, stream: io.StringIO, before_report, after_report
+    ) -> None:
+        """AC-17-01: after の内容が after_report の to_dict() と一致する。"""
+        fix_stats = {"total_fixed": 1, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        parsed = json.loads(stream.read())
+        expected_after = after_report.to_dict()
+        assert parsed["after"]["summary"] == expected_after["summary"]
+
+    def test_render_without_after_report_no_before_after_keys(
+        self, reporter, stream: io.StringIO, before_report
+    ) -> None:
+        """after_report=None の場合、JSON 出力に 'before'/'after' キーが含まれない（従来動作）。"""
+        reporter.render(before_report, fix_stats=None, after_report=None)
+
+        stream.seek(0)
+        parsed = json.loads(stream.read())
+        assert "before" not in parsed
+        assert "after" not in parsed
+
+    def test_render_without_after_report_contains_summary_top_level(
+        self, reporter, stream: io.StringIO, before_report
+    ) -> None:
+        """after_report=None の場合は従来通り top-level に summary, results が含まれる。"""
+        reporter.render(before_report, fix_stats=None, after_report=None)
+
+        stream.seek(0)
+        parsed = json.loads(stream.read())
+        assert "summary" in parsed
+        assert "results" in parsed
+
+    def test_render_with_after_report_is_valid_json(
+        self, reporter, stream: io.StringIO, before_report, after_report
+    ) -> None:
+        """AC-17-01: after_report を渡した場合も出力が有効な JSON である。"""
+        fix_stats = {"total_fixed": 0, "filter_stats": {"total_rows_removed": 0}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        content = stream.read()
+        parsed = json.loads(content)
+        assert isinstance(parsed, dict)
+
+
+# ---------------------------------------------------------------------------
+# AC-17: 修正前後レポート — RichReporter
+# ---------------------------------------------------------------------------
+
+
+class TestRichReporterFixReport:
+    """RichReporter の修正前後レポート出力テスト。
+
+    AC-17-03: --fix で Rich 修正前後レポートが表示される
+    """
+
+    @pytest.fixture
+    def before_report(self) -> Report:
+        """修正前レポート（WARNINGあり）。"""
+        warning_result = _make_check_result(
+            checker_name="text_length",
+            issues=[
+                _make_issue(
+                    checker="text_length",
+                    severity=Severity.WARNING,
+                    message="Text too short",
+                    row_indices=[0, 1],
+                )
+            ],
+        )
+        return _make_report(total_rows=5, results=[warning_result])
+
+    @pytest.fixture
+    def after_report(self) -> Report:
+        """修正後レポート（問題行除去済み）。"""
+        return _make_report(total_rows=3, results=[])
+
+    def _make_rich_reporter_with_stream(self) -> tuple:
+        """テスト用のRichReporterとキャプチャ用ストリームのペアを返す。"""
+        from io import StringIO
+        from rich.console import Console
+        from evaldataset.report import RichReporter
+
+        stream = StringIO()
+        console = Console(file=stream, highlight=False)
+        reporter = RichReporter(console=console)
+        return reporter, stream
+
+    def test_render_with_after_report_does_not_raise(
+        self, before_report, after_report
+    ) -> None:
+        """AC-17-03: after_report を渡した場合も render() が例外なく実行できる。"""
+        from evaldataset.report import RichReporter
+
+        reporter = RichReporter()
+        fix_stats = {"total_fixed": 1, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+    def test_render_with_after_report_output_contains_before(
+        self, before_report, after_report
+    ) -> None:
+        """AC-17-03: render() の出力に 'Before' が含まれる。"""
+        reporter, stream = self._make_rich_reporter_with_stream()
+        fix_stats = {"total_fixed": 1, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        output = stream.read()
+        assert "Before" in output
+
+    def test_render_with_after_report_output_contains_after(
+        self, before_report, after_report
+    ) -> None:
+        """AC-17-03: render() の出力に 'After' が含まれる。"""
+        reporter, stream = self._make_rich_reporter_with_stream()
+        fix_stats = {"total_fixed": 1, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        output = stream.read()
+        assert "After" in output
+
+    def test_render_without_after_report_no_before_after_text(
+        self, before_report
+    ) -> None:
+        """after_report=None の場合は従来動作（Before/After テキストなし）で動作する。"""
+        reporter, stream = self._make_rich_reporter_with_stream()
+        reporter.render(before_report, fix_stats=None, after_report=None)
+
+        stream.seek(0)
+        output = stream.read()
+        # before/after セクションは存在しない（従来の単一レポート表示）
+        # ただし例外なく動作すること
+        assert isinstance(output, str)
+
+    def test_render_with_after_report_shows_before_warnings_count(
+        self, before_report, after_report
+    ) -> None:
+        """AC-17-03: render() の出力に修正前の問題数が含まれる。"""
+        reporter, stream = self._make_rich_reporter_with_stream()
+        fix_stats = {"total_fixed": 2, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        output = stream.read()
+        # Before セクションに warnings 数が表示される
+        before_warnings = str(before_report.total_warnings)
+        assert before_warnings in output
+
+    def test_render_with_after_report_shows_after_total_rows(
+        self, before_report, after_report
+    ) -> None:
+        """AC-17-03: render() の出力に修正後の行数が含まれる。"""
+        reporter, stream = self._make_rich_reporter_with_stream()
+        fix_stats = {"total_fixed": 2, "filter_stats": {"total_rows_removed": 2}}
+        reporter.render(before_report, fix_stats=fix_stats, after_report=after_report)
+
+        stream.seek(0)
+        output = stream.read()
+        # After レポートの total_rows（3）が出力に含まれる
+        assert str(after_report.total_rows) in output


### PR DESCRIPTION
## Summary
- `--fix` / `--dry-run` 実行時に修正前後のチェック結果（before/after）を表示
- JSON出力: `before`/`fix_stats`/`after` のエンベロープ構造（`--fix` なしは後方互換）
- Rich出力: Before Fix / Fix Applied / After Fix の3セクション表示
- 修正前: 8 WARNING → 修正後: 2 WARNING のような改善度が一目でわかる

## Test plan
- [x] UT 432件 + IT 72件 = 504件全パス
- [x] AC-17-01〜03 の IT 13件カバー
- [x] code-reviewer: Major指摘なし
- [x] it-validator: Major指摘なし

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)