### PR TITLE
RowFilter に boilerplate をフィルタ対象に追加

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -385,6 +385,7 @@ TextCleaner を先に適用することで、クリーニングで解消され�
 | 近似重複の除去 | `NearDuplicateChecker` | 類似行（最初の 1 件を残す） |
 | 短文/長文のフィルタリング | `TextLengthChecker` | `min_length` 未満 / `max_length` 超過の行 |
 | PII を含む行の除去 | `PiiChecker` | PII（メールアドレス等）を含む行 |
+| ボイラープレートの除去 | `BoilerplateChecker` | 定型文・URL高密度・メール高密度の行 |
 
 **統計出力**: `filter_stats` として以下を記録する:
 - 各チェッカー名ごとの除去行数

--- a/src/evaldataset/fixer.py
+++ b/src/evaldataset/fixer.py
@@ -194,7 +194,7 @@ class RowFilter:
     """
 
     # Checker names whose Issue.row_indices drive row removal.
-    FILTER_CHECKERS = ["exact_duplicate", "near_duplicate", "text_length", "pii"]
+    FILTER_CHECKERS = ["exact_duplicate", "near_duplicate", "text_length", "pii", "boilerplate"]
 
     def filter_dataset(
         self,


### PR DESCRIPTION
## Summary
- `FILTER_CHECKERS` に `"boilerplate"` を追加
- URL高密度テキスト・定型文が `--fix` で除去されるようになる

## Test plan
- [x] 全535テストパス（既存UTがFILTER_CHECKERSの定数チェックを含むため自動検証）

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)